### PR TITLE
Auto deploy na nova hospedagem 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build e Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do Repositório
+        uses: actions/checkout@v4
+
+      - name: Instalar Dependências
+        run: npm install
+
+      - name: Build do Projeto
+        run: npm run build
+
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_HOST }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: ./dist/
+          server-dir: /public_html/


### PR DESCRIPTION
Este PR adiciona um workflow do GitHub Actions para realizar deploy automático do projeto na  nova hospedagem via FTP. Agora, sempre que um commit for enviado para a branch main, o workflow:

Faz checkout do repositório.
Instala as dependências (npm install).
Constrói o projeto (npm run build).
Faz upload da pasta dist/ para o servidor via FTP.