### PR TITLE
fix: gaveteiros não mostrando corretamente os valores no safari

### DIFF
--- a/src/styles/playground/playground.scss
+++ b/src/styles/playground/playground.scss
@@ -358,16 +358,16 @@ main {
                         }
 
                         div {
-                            position: absolute;
+                            position: relative;
 
                             @include global.middle;
 
                             &:first-child {
-                                @include numbers(40px, initial, 13, 88px, 86px);
+                                @include numbers(48px, initial, 13, 88px, 86px);
                             }
 
                             &:last-child {
-                                @include numbers(42px, 0, -28, 50px, 75px);
+                                @include numbers(-38px, -97px, -28, 50px, 75px);
                             }
 
                             span {


### PR DESCRIPTION
Quando tentado utilizar o playground do hvc, todos os texto da gaveta permanecem no mesmo lugar quando acessado em navegadores com WebKit. Este PR busca uma solução rápida para resolver este problema, sem mexer muito no código.

### Antes:  
<img src="https://github.com/user-attachments/assets/66f819ec-3bac-4080-a74c-77be5be60c31" alt="foto1" width="300">  
<img src="https://github.com/user-attachments/assets/7ffbe3de-9fb5-4c9d-b870-4f3c498ea64b" alt="foto2">  

### Depois:  
<img src="https://github.com/user-attachments/assets/427caba1-ce67-488b-aaef-73e2c58161c9" alt="foto3" width="300">  
<img src="https://github.com/user-attachments/assets/0c7631a4-dda4-4dcf-acd4-2222df450295" alt="foto4">

